### PR TITLE
Add persistent configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # mrss
 Multi RSS Reader
+
+## Configuration
+
+Configuration is stored in a platform-specific directory:
+
+- Windows: `%AppData%\\rssq\\config.toml`
+- Unix: `$XDG_CONFIG_HOME/rssq/config.toml` (defaults to `~/.config/rssq/config.toml`)
+
+The file is created on first run with default settings:
+
+```toml
+[ui]
+theme = "dark"
+unread_only = true
+
+[opener]
+command = "xdg-open" # platform specific default
+
+[keys]
+quit = "q"
+open = "o"
+refresh = "r"
+```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,13 +2,122 @@
 
 //! Application configuration handling.
 
-use directories::ProjectDirs;
+use directories::BaseDirs;
+use serde::{Deserialize, Serialize};
 
-/// Load configuration from the default location.
-pub fn load() -> Option<toml::Value> {
-    let dirs = ProjectDirs::from("com", "example", "mrss")?;
-    let config_path = dirs.config_dir().join("config.toml");
-    std::fs::read_to_string(config_path)
-        .ok()
-        .and_then(|s| toml::from_str(&s).ok())
+/// Global application configuration.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub ui: Ui,
+    pub opener: Opener,
+    pub keys: Keys,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Ui {
+    pub theme: Theme,
+    pub unread_only: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Opener {
+    pub command: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Keys {
+    pub quit: String,
+    pub open: String,
+    pub refresh: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Theme {
+    Dark,
+    Light,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ui: Ui::default(),
+            opener: Opener::default(),
+            keys: Keys::default(),
+        }
+    }
+}
+
+impl Default for Ui {
+    fn default() -> Self {
+        Self {
+            theme: Theme::Dark,
+            unread_only: true,
+        }
+    }
+}
+
+impl Default for Opener {
+    fn default() -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            Self {
+                command: "start".into(),
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            Self {
+                command: "open".into(),
+            }
+        }
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        {
+            Self {
+                command: "xdg-open".into(),
+            }
+        }
+    }
+}
+
+impl Default for Keys {
+    fn default() -> Self {
+        Self {
+            quit: "q".into(),
+            open: "o".into(),
+            refresh: "r".into(),
+        }
+    }
+}
+
+impl Config {
+    fn path() -> std::path::PathBuf {
+        BaseDirs::new()
+            .map(|d| d.config_dir().join("rssq").join("config.toml"))
+            .unwrap_or_else(|| std::path::PathBuf::from("config.toml"))
+    }
+
+    /// Load configuration from disk, creating it with defaults if missing.
+    pub fn load() -> std::io::Result<Self> {
+        let path = Self::path();
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            toml::from_str(&data)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        } else {
+            let cfg = Self::default();
+            cfg.save()?;
+            Ok(cfg)
+        }
+    }
+
+    /// Persist configuration to disk.
+    pub fn save(&self) -> std::io::Result<()> {
+        let path = Self::path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let data = toml::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(path, data)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ mod data;
 mod net;
 mod tui;
 
+use crate::config::Config;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Placeholder for initialization logic
+    let _config = Config::load()?;
     println!("mrss starting up");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add Config struct with ui, opener, and keys sections
- load and save config at platform-specific path with default values
- document config location and defaults in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abb76d17a08332b7b3e9589a0e030b