### PR TITLE
Implement network feed caching and refresh manager

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -5,9 +5,11 @@
 use std::{fs, io, path::PathBuf};
 
 use directories::BaseDirs;
+use feed_rs::model as feedmodel;
 use log::error;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
+use std::collections::HashMap;
 
 /// RSS item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +45,10 @@ pub struct Feed {
     pub title: String,
     #[serde(default)]
     pub items: Vec<Item>,
+    #[serde(default)]
+    pub etag: Option<String>,
+    #[serde(default)]
+    pub last_modified: Option<String>,
 }
 
 /// Grouping of feeds.
@@ -53,6 +59,78 @@ pub struct Group {
     pub feeds: Vec<Feed>,
     #[serde(default)]
     pub unread_count: usize,
+}
+
+impl Feed {
+    /// Merge parsed feed data into this feed, preserving read/queued flags.
+    pub fn merge_items(&mut self, parsed: feedmodel::Feed) {
+        // Update title if present
+        if let Some(title) = parsed.title {
+            self.title = title.content;
+        }
+
+        // Map existing items by id to preserve state
+        let existing: HashMap<String, Item> = self
+            .items
+            .iter()
+            .cloned()
+            .map(|i| (i.id.clone(), i))
+            .collect();
+
+        let mut new_items = Vec::new();
+        for entry in parsed.entries {
+            let link = entry
+                .links
+                .first()
+                .map(|l| l.href.clone())
+                .unwrap_or_default();
+            let id = Item::gen_id(Some(&entry.id), &link);
+
+            let mut item = Item {
+                id: id.clone(),
+                title: entry
+                    .title
+                    .as_ref()
+                    .map(|t| t.content.clone())
+                    .unwrap_or_default(),
+                link,
+                desc: entry
+                    .summary
+                    .as_ref()
+                    .map(|s| s.content.clone())
+                    .unwrap_or_default(),
+                timestamp: entry
+                    .published
+                    .or(entry.updated)
+                    .map(|d| d.timestamp())
+                    .unwrap_or_default(),
+                read: false,
+                queued: false,
+            };
+
+            if let Some(old) = existing.get(&id) {
+                item.read = old.read;
+                item.queued = old.queued;
+            }
+
+            new_items.push(item);
+        }
+
+        // Newest first by timestamp
+        new_items.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        self.items = new_items;
+    }
+}
+
+impl Group {
+    /// Recalculate unread count for the group.
+    pub fn update_unread(&mut self) {
+        self.unread_count = self
+            .feeds
+            .iter()
+            .map(|f| f.items.iter().filter(|i| !i.read).count())
+            .sum();
+    }
 }
 
 /// Resolve path to the database json file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,20 @@ mod net;
 mod tui;
 
 use crate::config::Config;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::net::refresh;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _config = Config::load()?;
+    let db = data::load_db().unwrap_or_default();
+    let db = Arc::new(Mutex::new(db));
+
+    // Spawn refresh manager; the returned sender can be triggered on F5.
+    let _refresh_trigger = refresh::spawn_refresh_manager(db.clone());
+
     println!("mrss starting up");
     Ok(())
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,11 +3,55 @@
 //! Networking and feed fetching utilities.
 
 use feed_rs::parser;
-use reqwest::Client;
+use reqwest::{Client, StatusCode, header};
 
-/// Fetch and parse a feed from a URL.
-pub async fn fetch_feed(url: &str) -> Result<feed_rs::model::Feed, Box<dyn std::error::Error>> {
-    let bytes = Client::new().get(url).send().await?.bytes().await?;
+/// Fetch a feed from the network respecting HTTP caching headers.
+///
+/// `etag` and `last_modified` are previously cached header values. If the
+/// remote server returns `304 Not Modified`, `None` will be returned for the
+/// feed data. The returned tuple contains the new header values along with the
+/// optional parsed feed.
+pub async fn fetch_feed(
+    url: &str,
+    etag: Option<&str>,
+    last_modified: Option<&str>,
+) -> Result<
+    (Option<String>, Option<String>, Option<feed_rs::model::Feed>),
+    Box<dyn std::error::Error>,
+> {
+    let client = Client::builder().build()?;
+    let mut req = client.get(url);
+    if let Some(et) = etag {
+        req = req.header(header::IF_NONE_MATCH, et);
+    }
+    if let Some(lm) = last_modified {
+        req = req.header(header::IF_MODIFIED_SINCE, lm);
+    }
+
+    let resp = req.send().await?;
+
+    let new_etag = resp
+        .headers()
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let new_last = resp
+        .headers()
+        .get(header::LAST_MODIFIED)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    if resp.status() == StatusCode::NOT_MODIFIED {
+        return Ok((
+            new_etag.or(etag.map(|s| s.to_string())),
+            new_last.or(last_modified.map(|s| s.to_string())),
+            None,
+        ));
+    }
+
+    let bytes = resp.bytes().await?;
     let feed = parser::parse(&bytes[..])?;
-    Ok(feed)
+    Ok((new_etag, new_last, Some(feed)))
 }
+
+pub mod refresh;

--- a/src/net/refresh.rs
+++ b/src/net/refresh.rs
@@ -1,0 +1,54 @@
+//! Background refresh manager for feeds.
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{
+    sync::{Mutex, mpsc},
+    time,
+};
+
+use crate::data::Group;
+
+use super::fetch_feed;
+
+/// Spawn the refresh manager. The returned sender can be used to trigger a
+/// manual refresh (e.g. when the user presses F5).
+pub fn spawn_refresh_manager(db: Arc<Mutex<Vec<Group>>>) -> mpsc::Sender<()> {
+    let (tx, mut rx) = mpsc::channel::<()>(1);
+
+    tokio::spawn(async move {
+        let mut ticker = time::interval(Duration::from_secs(900)); // 15min
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    refresh_all(&db).await;
+                }
+                Some(_) = rx.recv() => {
+                    refresh_all(&db).await;
+                }
+            }
+        }
+    });
+
+    tx
+}
+
+async fn refresh_all(db: &Arc<Mutex<Vec<Group>>>) {
+    let mut guard = db.lock().await;
+    for group in guard.iter_mut() {
+        for feed in group.feeds.iter_mut() {
+            if let Ok((etag, last, Some(parsed))) = fetch_feed(
+                &feed.url,
+                feed.etag.as_deref(),
+                feed.last_modified.as_deref(),
+            )
+            .await
+            {
+                feed.etag = etag;
+                feed.last_modified = last;
+                feed.merge_items(parsed);
+            }
+        }
+        group.update_unread();
+    }
+}


### PR DESCRIPTION
## Summary
- Add HTTP caching aware `fetch_feed` using reqwest+rustls
- Extend feed data with cache headers and merge logic preserving read state
- Introduce async refresh manager with timer or manual trigger and unread count updates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acf193f7e08332b112cf190d49dd95