### PR TITLE
Implement group and feed pane shortcuts

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,10 @@
 //! Terminal user interface components built with ratatui and crossterm.
 
 use std::time::{Duration, Instant};
+use std::{
+    io::{self, Write},
+    process::Command,
+};
 
 use crossterm::{
     event::{self, Event, KeyCode},
@@ -15,7 +19,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::Line,
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
 use crate::{
@@ -43,6 +47,8 @@ pub struct AppState {
     pub search: String,
     pub show_help: bool,
     pub config: Config,
+    pub selected_group: usize,
+    pub selected_feed: usize,
 }
 
 impl AppState {
@@ -57,8 +63,189 @@ impl AppState {
             show_help: false,
             config,
             groups,
+            selected_group: 0,
+            selected_feed: 0,
         }
     }
+}
+
+fn prompt(msg: &str) -> Option<String> {
+    disable_raw_mode().ok()?;
+    print!("{} ", msg);
+    let _ = io::stdout().flush();
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).ok()? == 0 {
+        let _ = enable_raw_mode();
+        return None;
+    }
+    let _ = enable_raw_mode();
+    let s = input.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn confirm(msg: &str) -> bool {
+    if let Some(ans) = prompt(&format!("{} [y/N]", msg)) {
+        matches!(ans.to_lowercase().as_str(), "y" | "yes")
+    } else {
+        false
+    }
+}
+
+fn open_link(opener: &str, url: &str) {
+    let _ = Command::new(opener).arg(url).spawn();
+}
+
+fn mark_feed_read(feed: &mut Feed) {
+    for item in &mut feed.items {
+        item.read = true;
+    }
+}
+
+fn mark_group_read(group: &mut Group) {
+    for feed in &mut group.feeds {
+        mark_feed_read(feed);
+    }
+    group.update_unread();
+}
+
+fn open_unread_feed(feed: &mut Feed, opener: &str) {
+    for item in &mut feed.items {
+        if !item.read {
+            open_link(opener, &item.link);
+            item.read = true;
+        }
+    }
+}
+
+fn open_unread_group(group: &mut Group, opener: &str) {
+    for feed in &mut group.feeds {
+        open_unread_feed(feed, opener);
+    }
+    group.update_unread();
+}
+
+fn handle_groups_key(code: KeyCode, app: &mut AppState) -> Result<(), Box<dyn std::error::Error>> {
+    match code {
+        KeyCode::Up => {
+            if app.selected_group > 0 {
+                app.selected_group -= 1;
+                app.selected_feed = 0;
+            }
+        }
+        KeyCode::Down => {
+            if app.selected_group + 1 < app.groups.len() {
+                app.selected_group += 1;
+                app.selected_feed = 0;
+            }
+        }
+        KeyCode::Right => {
+            app.focus = Pane::Feeds;
+        }
+        KeyCode::Char('a') => {
+            if let Some(name) = prompt("New group name:") {
+                app.groups.push(Group {
+                    name,
+                    ..Group::default()
+                });
+                app.selected_group = app.groups.len() - 1;
+                app.selected_feed = 0;
+            }
+        }
+        KeyCode::Char('d') => {
+            if !app.groups.is_empty() {
+                let name = app.groups[app.selected_group].name.clone();
+                if confirm(&format!("Delete group '{}' ?", name)) {
+                    app.groups.remove(app.selected_group);
+                    if app.selected_group >= app.groups.len() && app.selected_group > 0 {
+                        app.selected_group -= 1;
+                    }
+                    app.selected_feed = 0;
+                }
+            }
+        }
+        KeyCode::Char('r') => {
+            if let Some(group) = app.groups.get_mut(app.selected_group) {
+                if let Some(name) = prompt("Rename group:") {
+                    group.name = name;
+                }
+            }
+        }
+        KeyCode::Char('A') => {
+            if let Some(group) = app.groups.get_mut(app.selected_group) {
+                mark_group_read(group);
+            }
+        }
+        KeyCode::Char('O') => {
+            if let Some(group) = app.groups.get_mut(app.selected_group) {
+                if confirm("Open all unread items in group?") {
+                    let opener = app.config.opener.command.clone();
+                    open_unread_group(group, &opener);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn handle_feeds_key(code: KeyCode, app: &mut AppState) -> Result<(), Box<dyn std::error::Error>> {
+    if app.groups.is_empty() {
+        return Ok(());
+    }
+    let g = app.selected_group;
+    match code {
+        KeyCode::Up => {
+            if app.selected_feed > 0 {
+                app.selected_feed -= 1;
+            }
+        }
+        KeyCode::Down => {
+            if app.selected_feed + 1 < app.groups[g].feeds.len() {
+                app.selected_feed += 1;
+            }
+        }
+        KeyCode::Left => {
+            app.focus = Pane::Groups;
+        }
+        KeyCode::Char('a') => {
+            if let Some(url) = prompt("Feed URL:") {
+                let feed = Feed {
+                    url: url.clone(),
+                    title: url,
+                    ..Feed::default()
+                };
+                app.groups[g].feeds.push(feed);
+                app.selected_feed = app.groups[g].feeds.len() - 1;
+            }
+        }
+        KeyCode::Char('d') => {
+            if !app.groups[g].feeds.is_empty() {
+                let title = app.groups[g].feeds[app.selected_feed].title.clone();
+                if confirm(&format!("Delete feed '{}' ?", title)) {
+                    app.groups[g].feeds.remove(app.selected_feed);
+                    if app.selected_feed >= app.groups[g].feeds.len() && app.selected_feed > 0 {
+                        app.selected_feed -= 1;
+                    }
+                    app.groups[g].update_unread();
+                }
+            }
+        }
+        KeyCode::Char('A') => {
+            if let Some(feed) = app.groups[g].feeds.get_mut(app.selected_feed) {
+                mark_feed_read(feed);
+                app.groups[g].update_unread();
+            }
+        }
+        KeyCode::Char('O') => {
+            if let Some(feed) = app.groups[g].feeds.get_mut(app.selected_feed) {
+                let opener = app.config.opener.command.clone();
+                open_unread_feed(feed, &opener);
+                app.groups[g].update_unread();
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Run the application event loop.
@@ -89,7 +276,11 @@ pub fn run_app(app: &mut AppState) -> Result<(), Box<dyn std::error::Error>> {
                     KeyCode::F(1) => {
                         app.show_help = !app.show_help;
                     }
-                    _ => {}
+                    _ => match app.focus {
+                        Pane::Groups => handle_groups_key(key.code, app)?,
+                        Pane::Feeds => handle_feeds_key(key.code, app)?,
+                        _ => {}
+                    },
                 },
                 Event::Resize(_, _) => {
                     // just trigger a redraw on next loop
@@ -120,11 +311,35 @@ fn ui(f: &mut Frame, app: &AppState) {
         ])
         .split(f.size());
 
-    let groups_block = Block::default().title("Groups").borders(Borders::ALL);
-    f.render_widget(groups_block, chunks[0]);
+    let group_items: Vec<ListItem> = app
+        .groups
+        .iter()
+        .map(|g| ListItem::new(g.name.clone()))
+        .collect();
+    let groups_list =
+        List::new(group_items).block(Block::default().title("Groups").borders(Borders::ALL));
+    let mut group_state = ListState::default();
+    if !app.groups.is_empty() {
+        group_state.select(Some(app.selected_group.min(app.groups.len() - 1)));
+    }
+    f.render_stateful_widget(groups_list, chunks[0], &mut group_state);
 
-    let feeds_block = Block::default().title("Feeds").borders(Borders::ALL);
-    f.render_widget(feeds_block, chunks[1]);
+    let feeds = app
+        .groups
+        .get(app.selected_group)
+        .map(|g| g.feeds.as_slice())
+        .unwrap_or(&[]);
+    let feed_items: Vec<ListItem> = feeds
+        .iter()
+        .map(|f| ListItem::new(f.title.clone()))
+        .collect();
+    let feeds_list =
+        List::new(feed_items).block(Block::default().title("Feeds").borders(Borders::ALL));
+    let mut feed_state = ListState::default();
+    if !feeds.is_empty() {
+        feed_state.select(Some(app.selected_feed.min(feeds.len() - 1)));
+    }
+    f.render_stateful_widget(feeds_list, chunks[1], &mut feed_state);
 
     let right_chunks = Layout::default()
         .direction(Direction::Vertical)


### PR DESCRIPTION
## Summary
- Add input and confirmation helpers for TUI interactions
- Implement groups pane shortcuts for adding, deleting, renaming, marking read, and opening unread items
- Implement feeds pane shortcuts for adding, deleting, marking read, and opening unread items
- Render group and feed lists with selection support

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68acf45abf808332ad79229fd370053f