### PR TITLE
Add search, sorting, and auto-refresh to TUI

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,12 +11,17 @@ pub struct Config {
     pub ui: Ui,
     pub opener: Opener,
     pub keys: Keys,
+    #[serde(default)]
+    pub refresh: Refresh,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Ui {
     pub theme: Theme,
+    #[serde(default)]
     pub unread_only: bool,
+    #[serde(default)]
+    pub sort: SortOrder,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -38,11 +43,36 @@ pub enum Theme {
     Light,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Date,
+    Title,
+    Channel,
+}
+
+impl Default for SortOrder {
+    fn default() -> Self {
+        SortOrder::Date
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Refresh {
+    #[serde(default = "default_interval")]
+    pub interval_secs: u64,
+}
+
+const fn default_interval() -> u64 {
+    900
+}
+
 impl Default for Ui {
     fn default() -> Self {
         Self {
             theme: Theme::Dark,
             unread_only: true,
+            sort: SortOrder::Date,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,52 @@ mod net;
 mod tui;
 
 use crate::config::Config;
+use chrono::Utc;
+use std::{
+    sync::{Arc, Mutex, mpsc},
+    thread,
+    time::Duration,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
-    let groups = data::load_db().unwrap_or_default();
-    let mut app = tui::AppState::new(config, groups);
+    let groups = Arc::new(Mutex::new(data::load_db().unwrap_or_default()));
+    let (tx, rx) = mpsc::channel();
+    let interval = config.refresh.interval_secs;
+    let groups_clone = Arc::clone(&groups);
+    thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        loop {
+            let mut new_items = 0;
+            rt.block_on(async {
+                let mut guard = groups_clone.lock().unwrap();
+                for group in guard.iter_mut() {
+                    for feed in group.feeds.iter_mut() {
+                        let prev = feed.items.len();
+                        if let Ok((etag, last, Some(parsed))) = net::fetch_feed(
+                            &feed.url,
+                            feed.etag.as_deref(),
+                            feed.last_modified.as_deref(),
+                        )
+                        .await
+                        {
+                            feed.etag = etag;
+                            feed.last_modified = last;
+                            feed.merge_items(parsed);
+                            if feed.items.len() > prev {
+                                new_items += feed.items.len() - prev;
+                            }
+                        }
+                    }
+                    group.update_unread();
+                }
+            });
+            let _ = tx.send((Utc::now(), new_items));
+            thread::sleep(Duration::from_secs(interval));
+        }
+    });
+
+    let mut app = tui::AppState::new(config, groups, rx);
     tui::run_app(&mut app)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add search mode with substring filtering and sort preference
- enable unread toggle, focus cycling, and status bar
- spawn background refresher honoring configured interval

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acfabcfbfc8332949b8905df0699c2